### PR TITLE
issue#3 use proper splat operator to pass hash arguments with newer r…

### DIFF
--- a/labelary.gemspec
+++ b/labelary.gemspec
@@ -19,6 +19,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
+  spec.required_ruby_version = ">= 2.0"
+
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'pry'

--- a/lib/labelary/image.rb
+++ b/lib/labelary/image.rb
@@ -1,7 +1,7 @@
 module Labelary
   class Image
-    def self.encode(*args)
-      self.new(*args).encode
+    def self.encode(**args)
+      self.new(**args).encode
     end
 
     def initialize(path:nil, mime_type:, filename:nil, file_io:nil)

--- a/lib/labelary/label.rb
+++ b/lib/labelary/label.rb
@@ -1,7 +1,7 @@
 module Labelary
   class Label
-    def self.render(*args)
-      self.new(*args).render
+    def self.render(**args)
+      self.new(**args).render
     end
 
     def initialize(dpmm: nil, width: nil, height: nil, index: nil, zpl:, content_type: nil, font: nil)

--- a/lib/labelary/version.rb
+++ b/lib/labelary/version.rb
@@ -1,3 +1,3 @@
 module Labelary
-  VERSION = '0.3.0'
+  VERSION = '0.4.0'
 end


### PR DESCRIPTION
Found the current issue while upgrade our project. to ruby3 

```
3.0.2 :006 > Class.test(zpl: 'test')
    108: def self.test(*args)
    109:     args
 => 110: end
=> [{:zpl=>"test"}]
=> Return an array

3.0.2 :008 > Class.test(zpl: 'test')
    108: def self.test(**args)
    109:     args
 => 110: end
=> {:zpl=>"test"}
=> Return a hash
```

@rjocoleman 