### PR TITLE
Issue #7 - Changes default index value from 0 to ''

### DIFF
--- a/lib/labelary/configuration.rb
+++ b/lib/labelary/configuration.rb
@@ -29,7 +29,7 @@ module Labelary
       @dpmm         = nil
       @width        = nil
       @height       = nil
-      @index        = 0
+      @index        = ''
       @content_type = 'image/png'
       @font         = ''
     end


### PR DESCRIPTION
Solves https://github.com/rjocoleman/labelary/issues/7
- Changes default index value from 0 to '' (empty string), so if configuration.index is not set by the user, by default the label render will return all pages instead of only the first one.